### PR TITLE
Reduce docker image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,18 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
+COPY Makefile Makefile
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY utils/ utils/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
 
 # Build the docker image
-docker-build: test
+docker-build:
 	docker build . -t ${IMG}
 	docker build . -t ${WORKERIMG} --file Dockerfile.worker
 	@echo "updating kustomize image patch file for manager resource"


### PR DESCRIPTION
- `Dockerfile` changed to use `make manager` target
- Remove `test` dependency from `make docker-build` target (the code should already be tested in prior build steps)