### PR TITLE
controllers: cap worker Job name at 63 chars so long PodCheckpoints reconcile

### DIFF
--- a/controllers/podcheckpoint_controller.go
+++ b/controllers/podcheckpoint_controller.go
@@ -17,6 +17,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -144,9 +146,10 @@ func (r *PodCheckpointReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		s = append(s, id)
 	}
 
+	jobName := buildWorkerJobName(podCheckpoint.Name)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podCheckpoint.Name + "-job",
+			Name:      jobName,
 			Namespace: r.WorkerNamespace,
 			Labels: map[string]string{
 				"env": "security",
@@ -154,7 +157,7 @@ func (r *PodCheckpointReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"job": podCheckpoint.Name + "-job"}},
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"job": jobName}},
 				Spec: corev1.PodSpec{
 					NodeName:    pod.Spec.NodeName,
 					HostNetwork: true,
@@ -253,4 +256,32 @@ func (r *PodCheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&forensicsv1alpha1.PodCheckpoint{}).
 		Complete(r)
+}
+
+// buildWorkerJobName returns a Job name derived from a PodCheckpoint's name
+// that is guaranteed to stay inside the 63-character Kubernetes label limit.
+// For short names the legacy "<name>-job" form is kept verbatim so existing
+// jobs continue to reconcile; for names that would overflow, the PodCheckpoint
+// name is truncated and a short sha256 fingerprint is appended to keep the
+// result unique and deterministic (#20).
+func buildWorkerJobName(podCheckpointName string) string {
+	const max = 63
+	const suffix = "-job"
+
+	name := podCheckpointName + suffix
+	if len(name) <= max {
+		return name
+	}
+
+	sum := sha256.Sum256([]byte(podCheckpointName))
+	hashSuffix := "-" + hex.EncodeToString(sum[:])[:8] + suffix
+	prefixBudget := max - len(hashSuffix)
+	if prefixBudget < 0 {
+		prefixBudget = 0
+	}
+	prefix := podCheckpointName
+	if len(prefix) > prefixBudget {
+		prefix = prefix[:prefixBudget]
+	}
+	return prefix + hashSuffix
 }


### PR DESCRIPTION
## Description

The Job created for every PodCheckpoint used `podCheckpoint.Name + "-job"` as both its `metadata.name` and its pod-template `job` label. Any PodCheckpoint whose name was 60+ characters blew past the Kubernetes 63-character label limit and the reconcile loop failed on every pass with:

```
Job.batch "<name>-job" is invalid:
  spec.template.labels: Invalid value: "<name>-job": must be no more than 63 characters
```

Fixes #20.

## Change

- New `buildWorkerJobName(pcName string) string` helper:
  - If `len(pcName + "-job") <= 63`, return the legacy `"<name>-job"` form unchanged so existing reconciles are undisturbed.
  - Otherwise, truncate `pcName` and append a short `sha256` fingerprint plus `"-job"` so the result stays inside 63 characters and is stable/unique for a given PodCheckpoint.
- Thread the derived `jobName` through both `ObjectMeta.Name` and the pod-template `job` label so they stay in sync.

## Testing

- `make test` passes.
- Local regression: a PodCheckpoint with a 70-character name now produces a 63-char job name whose first segment is the truncated original and whose suffix is `-<8-hex>-job`; reconcile succeeds where before it failed with the label-length error.

## Checklist

- [x] I've read the CONTRIBUTING doc
- [x] I've run `make test` locally and all tests pass
- [x] I've signed-off my commits with `git commit -s` for DCO verification
