### PR TITLE
Bump Go from 1.25 to 1.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-- 1.12.x
+- 1.26.x
 
 git:
   depth: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.26 as builder
 MAINTAINER todd.ekenstam@intuit.com
 
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keikoproj/kube-forensics
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v0.1.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bring kube-forensics onto currently supported Go 1.26 (Go 1.25 is EOL).

- `go.mod`: `go 1.25.0` → `go 1.26.0` (`go mod tidy` made no further changes)
- `Dockerfile`: `golang:1.12.5` → `golang:1.26` (controller builder image)
- `.travis.yml`: `1.12.x` → `1.26.x` (only CI in this repo; Travis has no `go-version-file`)

`Dockerfile.worker` does not use a Go image and was left unchanged. There is no GitHub Actions workflow or golangci-lint config to update.

## Notes

`go build` / `go test` fail with a **pre-existing** Kubernetes module mismatch (also reproduces on Go 1.25 with the current `go.mod`):

```
k8s.io/client-go/rest: not enough arguments in call to watch.NewStreamWatcher
```

That comes from Dependabot’s `k8s.io/apimachinery` bump to `v0.15.7` against `k8s.io/client-go v11.0.1-…` (`#28`), not from this toolchain bump. Fixing it needs a coordinated k8s client / controller-runtime upgrade and is out of scope here.

## Test plan

- [x] `GOTOOLCHAIN=go1.26.0 go version` → `go1.26.0`
- [x] `GOTOOLCHAIN=go1.26.0 go mod tidy` (no `go.sum` changes)
- [x] Confirmed the `NewStreamWatcher` compile error also fails on Go 1.25 with `go 1.25.0`
- [ ] Reviewer: merge when ready (do not auto-merge)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16623111-ba51-4aeb-ae11-f5ff1d3991a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16623111-ba51-4aeb-ae11-f5ff1d3991a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

